### PR TITLE
Source url fixed as suggested

### DIFF
--- a/net/eoip/Makefile
+++ b/net/eoip/Makefile
@@ -13,7 +13,7 @@ PKG_RELEASE:=1
 PKG_MAINTAINER:=bogdik <bogdikxxx@mail.ru>
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://github.com/bogdik/openwrt-linux-eoip/releases/download/0.5/
+PKG_SOURCE_URL:=https://github.com/bogdik/openwrt-linux-eoip/releases/tag/0.6.1
 PKG_HASH:=22f6f3864665adef26c7fbd57543a396108ba2dff1282af8143f18bc2a9912f8
 
 PKG_INSTALL:=1


### PR DESCRIPTION
https://github.com/bogdik/openwrt-linux-eoip/releases/tag/0.6.1

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
