### PR TITLE
PKG_VERSION changed

### DIFF
--- a/net/eoip/Makefile
+++ b/net/eoip/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=eoip
-PKG_VERSION:=0.5
+PKG_VERSION:=0.6.1
 PKG_RELEASE:=1
 PKG_MAINTAINER:=bogdik <bogdikxxx@mail.ru>
 PKG_LICENSE:=GPL-3.0-or-later


### PR DESCRIPTION
PKG_VERSION changed as suggested https://github.com/openwrt/packages/pull/14334#discussion_r549481485

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
